### PR TITLE
Add Dark Mode to Changelog

### DIFF
--- a/Changelog.Designer.cs
+++ b/Changelog.Designer.cs
@@ -32,10 +32,9 @@ namespace Stand_Launchpad
         {
             this.webBrowser1 = new System.Windows.Forms.WebBrowser();
             this.SuspendLayout();
-
-            // 
+            //
             // webBrowser1
-            // 
+            //
             this.webBrowser1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.webBrowser1.Location = new System.Drawing.Point(0, 0);
             this.webBrowser1.MinimumSize = new System.Drawing.Size(20, 20);
@@ -43,10 +42,9 @@ namespace Stand_Launchpad
             this.webBrowser1.Size = new System.Drawing.Size(800, 450);
             this.webBrowser1.TabIndex = 0;
             this.webBrowser1.Url = new System.Uri("https://stand.gg/help/changelog-launchpad", System.UriKind.Absolute);
-
-            // 
+            //
             // Changelog
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
@@ -54,8 +52,8 @@ namespace Stand_Launchpad
             this.Name = "Changelog";
             this.Text = "Changelog";
             this.Icon = ((System.Drawing.Icon)(new System.ComponentModel.ComponentResourceManager(typeof(Launchpad))).GetObject("$this.Icon"));
-            this.webBrowser1.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.webBrowser1_DocumentCompleted);
             this.ResumeLayout(false);
+
         }
 
         #endregion
@@ -69,7 +67,7 @@ namespace Stand_Launchpad
             var script = document.CreateElement("script");
             script.SetAttribute("type", "text/javascript");
             script.SetAttribute("text", @"document.body.style.backgroundColor = '#101110';
-                              document.body.style.color = '#fefffe';            
+                              document.body.style.color = '#fefffe';
                               var h2Elements = document.getElementsByTagName('h2');
                               for (var i = 0; i < h2Elements.length; i++) {
                                 h2Elements[i].style.color = '#dcdcdc';

--- a/Changelog.Designer.cs
+++ b/Changelog.Designer.cs
@@ -1,6 +1,4 @@
-﻿using System.Windows.Forms;
-
-namespace Stand_Launchpad
+﻿namespace Stand_Launchpad
 {
     partial class Changelog
     {
@@ -32,9 +30,9 @@ namespace Stand_Launchpad
         {
             this.webBrowser1 = new System.Windows.Forms.WebBrowser();
             this.SuspendLayout();
-            //
+            // 
             // webBrowser1
-            //
+            // 
             this.webBrowser1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.webBrowser1.Location = new System.Drawing.Point(0, 0);
             this.webBrowser1.MinimumSize = new System.Drawing.Size(20, 20);
@@ -42,9 +40,9 @@ namespace Stand_Launchpad
             this.webBrowser1.Size = new System.Drawing.Size(800, 450);
             this.webBrowser1.TabIndex = 0;
             this.webBrowser1.Url = new System.Uri("https://stand.gg/help/changelog-launchpad", System.UriKind.Absolute);
-            //
+            // 
             // Changelog
-            //
+            // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
@@ -59,28 +57,5 @@ namespace Stand_Launchpad
         #endregion
 
         private System.Windows.Forms.WebBrowser webBrowser1;
-
-        private void ApplyDarkMode()
-        {
-            var document = webBrowser1.Document;
-
-            var script = document.CreateElement("script");
-            script.SetAttribute("type", "text/javascript");
-            script.SetAttribute("text", @"document.body.style.backgroundColor = '#101110';
-                              document.body.style.color = '#fefffe';
-                              var h2Elements = document.getElementsByTagName('h2');
-                              for (var i = 0; i < h2Elements.length; i++) {
-                                h2Elements[i].style.color = '#dcdcdc';
-                              }
-                              ");
-
-            var head = document.GetElementsByTagName("head")[0];
-            head.AppendChild(script);
-        }
-
-        private void webBrowser1_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)
-        {
-            ApplyDarkMode();
-        }
     }
 }

--- a/Changelog.Designer.cs
+++ b/Changelog.Designer.cs
@@ -1,61 +1,88 @@
-﻿namespace Stand_Launchpad
+﻿using System.Windows.Forms;
+
+namespace Stand_Launchpad
 {
-	partial class Changelog
-	{
-		/// <summary>
-		/// Required designer variable.
-		/// </summary>
-		private System.ComponentModel.IContainer components = null;
+    partial class Changelog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
 
-		/// <summary>
-		/// Clean up any resources being used.
-		/// </summary>
-		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing && (components != null))
-			{
-				components.Dispose();
-			}
-			base.Dispose(disposing);
-		}
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
 
-		#region Windows Form Designer generated code
+        #region Windows Form Designer generated code
 
-		/// <summary>
-		/// Required method for Designer support - do not modify
-		/// the contents of this method with the code editor.
-		/// </summary>
-		private void InitializeComponent()
-		{
-			this.webBrowser1 = new System.Windows.Forms.WebBrowser();
-			this.SuspendLayout();
-			// 
-			// webBrowser1
-			// 
-			this.webBrowser1.Dock = System.Windows.Forms.DockStyle.Fill;
-			this.webBrowser1.Location = new System.Drawing.Point(0, 0);
-			this.webBrowser1.MinimumSize = new System.Drawing.Size(20, 20);
-			this.webBrowser1.Name = "webBrowser1";
-			this.webBrowser1.Size = new System.Drawing.Size(800, 450);
-			this.webBrowser1.TabIndex = 0;
-			this.webBrowser1.Url = new System.Uri("https://stand.gg/help/changelog-launchpad", System.UriKind.Absolute);
-			// 
-			// Changelog
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(800, 450);
-			this.Controls.Add(this.webBrowser1);
-			this.Name = "Changelog";
-			this.Text = "Changelog";
-			this.Icon = ((System.Drawing.Icon)(new System.ComponentModel.ComponentResourceManager(typeof(Launchpad))).GetObject("$this.Icon"));
-			this.ResumeLayout(false);
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.webBrowser1 = new System.Windows.Forms.WebBrowser();
+            this.SuspendLayout();
 
-		}
+            // 
+            // webBrowser1
+            // 
+            this.webBrowser1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.webBrowser1.Location = new System.Drawing.Point(0, 0);
+            this.webBrowser1.MinimumSize = new System.Drawing.Size(20, 20);
+            this.webBrowser1.Name = "webBrowser1";
+            this.webBrowser1.Size = new System.Drawing.Size(800, 450);
+            this.webBrowser1.TabIndex = 0;
+            this.webBrowser1.Url = new System.Uri("https://stand.gg/help/changelog-launchpad", System.UriKind.Absolute);
 
-		#endregion
+            // 
+            // Changelog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.webBrowser1);
+            this.Name = "Changelog";
+            this.Text = "Changelog";
+            this.Icon = ((System.Drawing.Icon)(new System.ComponentModel.ComponentResourceManager(typeof(Launchpad))).GetObject("$this.Icon"));
+            this.webBrowser1.DocumentCompleted += new System.Windows.Forms.WebBrowserDocumentCompletedEventHandler(this.webBrowser1_DocumentCompleted);
+            this.ResumeLayout(false);
+        }
 
-		private System.Windows.Forms.WebBrowser webBrowser1;
-	}
+        #endregion
+
+        private System.Windows.Forms.WebBrowser webBrowser1;
+
+        private void ApplyDarkMode()
+        {
+            var document = webBrowser1.Document;
+
+            var script = document.CreateElement("script");
+            script.SetAttribute("type", "text/javascript");
+            script.SetAttribute("text", @"document.body.style.backgroundColor = '#101110';
+                              document.body.style.color = '#fefffe';            
+                              var h2Elements = document.getElementsByTagName('h2');
+                              for (var i = 0; i < h2Elements.length; i++) {
+                                h2Elements[i].style.color = '#dcdcdc';
+                              }
+                              ");
+
+            var head = document.GetElementsByTagName("head")[0];
+            head.AppendChild(script);
+        }
+
+        private void webBrowser1_DocumentCompleted(object sender, WebBrowserDocumentCompletedEventArgs e)
+        {
+            ApplyDarkMode();
+        }
+    }
 }

--- a/Changelog.cs
+++ b/Changelog.cs
@@ -19,6 +19,7 @@ namespace Stand_Launchpad
         public Changelog()
 		{
 			InitializeComponent();
+            // dark mode title bar
             if (DwmSetWindowAttribute(Handle, 19, new[] { 1 }, 4) != 0)
             {
                 DwmSetWindowAttribute(Handle, 20, new[] { 1 }, 4);

--- a/Changelog.cs
+++ b/Changelog.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -12,9 +13,16 @@ namespace Stand_Launchpad
 {
 	public partial class Changelog : Form
 	{
-		public Changelog()
+        [DllImport("dwmapi.dll")]
+        private static extern int DwmSetWindowAttribute(IntPtr hwnd, int attr, int[] attrValue, int attrSize);
+
+        public Changelog()
 		{
 			InitializeComponent();
-		}
-	}
+            if (DwmSetWindowAttribute(Handle, 19, new[] { 1 }, 4) != 0)
+            {
+                DwmSetWindowAttribute(Handle, 20, new[] { 1 }, 4);
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hi, I've added Dark Mode to the Changelog page too to keep the same style through the entire launcher.
Here's a picture of the actual result:

![image](https://user-images.githubusercontent.com/66976091/235323811-65b957de-a4ae-4bc2-94ab-a9217fae67fe.png)
