### PR TITLE
Prevent having more than one instance opened

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cs text eof=crlf

--- a/Launchpad.cs
+++ b/Launchpad.cs
@@ -70,9 +70,10 @@ namespace Stand_Launchpad
 
 		public Launchpad()
 		{
+		        int currentProcessId = Process.GetCurrentProcess().Id;
 			foreach (Process process in Process.GetProcesses())
 			{
-				if (process.ProcessName == "Stand Launchpad")
+				if (process.ProcessName == "Stand Launchpad" && process.Id != currentProcessId)
 				{
 					showMessageBox("There's another instance of the Stand Launchpad already running!");
                     			Environment.Exit(1);

--- a/Launchpad.cs
+++ b/Launchpad.cs
@@ -70,6 +70,16 @@ namespace Stand_Launchpad
 
 		public Launchpad()
 		{
+			foreach (Process process in Process.GetProcesses())
+			{
+				if (process.ProcessName == "Stand Launchpad")
+				{
+					showMessageBox("There's another instance of the Stand Launchpad already running!");
+                    			Environment.Exit(1);
+                    			break;
+                		}
+			}
+			
 			InitializeComponent();
 			width_advanced = Width;
 			Text += " " + launchpad_display_version;

--- a/Launchpad.cs
+++ b/Launchpad.cs
@@ -247,11 +247,28 @@ namespace Stand_Launchpad
 				progressBar1.Value = download_progress;
 			}
 			while (!t.Wait(20));
-			File.Move(stand_dll + ".tmp", stand_dll);
-			if (new FileInfo(stand_dll).Length < 1024)
+
+            try
+            {
+                File.Move(stand_dll + ".tmp", stand_dll);
+			}
+			catch (IOException)
 			{
-				File.Delete(stand_dll);
-				showMessageBox("It looks like the DLL download has failed. Ensure you have no anti-virus program interfering.");
+                showMessageBox("It looks like the DLL file is currently being used. Ensure you have no other programs interfering.");
+            }
+
+            if (new FileInfo(stand_dll).Length < 1024)
+			{
+                try
+                {
+					File.Delete(stand_dll);
+				}
+				catch(IOException)
+				{
+                    showMessageBox("It looks like the DLL file is currently being used and we cannot delete it. Ensure you have no other programs interfering.");
+                }
+
+                showMessageBox("It looks like the DLL download has failed. Ensure you have no anti-virus program interfering.");
 				success = false;
 			}
 			progressBar1.Hide();

--- a/Launchpad.cs
+++ b/Launchpad.cs
@@ -248,27 +248,27 @@ namespace Stand_Launchpad
 			}
 			while (!t.Wait(20));
 
-            try
-            {
-                File.Move(stand_dll + ".tmp", stand_dll);
+			try
+			{
+				File.Move(stand_dll + ".tmp", stand_dll);
 			}
 			catch (IOException)
 			{
-                showMessageBox("It looks like the DLL file is currently being used. Ensure you have no other programs interfering.");
-            }
+				showMessageBox("It looks like the DLL file is currently being used. Ensure you have no other programs interfering.");
+			}
 
-            if (new FileInfo(stand_dll).Length < 1024)
-			{
-                try
-                {
+			if (new FileInfo(stand_dll).Length < 1024)
+			{	
+				try
+                		{
 					File.Delete(stand_dll);
 				}
 				catch(IOException)
 				{
-                    showMessageBox("It looks like the DLL file is currently being used and we cannot delete it. Ensure you have no other programs interfering.");
-                }
+                    			showMessageBox("It looks like the DLL file is currently being used and we cannot delete it. Ensure you have no other programs interfering.");
+                		}
 
-                showMessageBox("It looks like the DLL download has failed. Ensure you have no anti-virus program interfering.");
+                		showMessageBox("It looks like the DLL download has failed. Ensure you have no anti-virus program interfering.");
 				success = false;
 			}
 			progressBar1.Hide();


### PR DESCRIPTION
Hi, mistakenly I've opened two launchpads together and found this exception:

![image](https://user-images.githubusercontent.com/66976091/236535145-2442121f-c541-4292-bdcf-ef2ce93f9035.png)

Now with my edits the launcher intead of dying it catches the exception and tells the user what is actually going on:

![image](https://user-images.githubusercontent.com/66976091/236535342-2d66323f-58fb-45e2-8883-2bd43c5a30bc.png)

Funny to see that even replacing by copy pasting the spaces it still kills the formatting everytime :skull: (Apparently GitHub web or my browser changes tabs to spaces which is really annoying)