### PR TITLE
Respect User Input for Auto Injection After Game Restart

### DIFF
--- a/Launchpad.cs
+++ b/Launchpad.cs
@@ -372,7 +372,7 @@ namespace Stand_Launchpad
 				if (game_was_open)
 				{
 					game_was_open = false;
-					can_auto_inject = false;
+					can_auto_inject = AutoInjectCheckBox.Checked;
 					GameClosedTimer.Start();
 				}
 			}


### PR DESCRIPTION
The user input was not being honored, which meant that if the game was restarted, the launchpad failed to automatically inject the DLL as intended.